### PR TITLE
fix for Security Hub GuardDuty regex error

### DIFF
--- a/source/lambda/es_loader/siem/sf_securityhub.py
+++ b/source/lambda/es_loader/siem/sf_securityhub.py
@@ -12,7 +12,7 @@ from datetime import datetime
 
 from siem import utils
 
-RE_GDTYPE = re.compile(r"/(?P<ThreatPurpose>\w+)"
+RE_GDTYPE = re.compile(r"/(?P<ThreatPurpose>\w+\s?\w+)"
                        r"(:|/)(?P<ResourceTypeAffected>\w*)"
                        r"(/|.|-)(?P<ThreatFamilyName>[\w\&]*)")
 


### PR DESCRIPTION
*Issue #, if available:*
#179 
*Description of changes:*
This fix adjusts the regex to work with a space in the threat name:
"Initial Access" fails the regex pattern and causes the loader to crash.
TTPs/Initial Access/IAMUser-AnomalousBehavior

The updated regex in this pull requests fixes that issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
