### PR TITLE
fix for GuardDuty regex

### DIFF
--- a/source/lambda/es_loader/siem/sf_guardduty.py
+++ b/source/lambda/es_loader/siem/sf_guardduty.py
@@ -19,8 +19,9 @@ def transform(logdata):
         label = "medium"
     elif logdata['severity'] <= 8.9:
         label = "high"
-    r = re.compile(r"(?P<ThreatPurpose>\w*):(?P<ResourceTypeAffected>\w*)/"
-                   r"(?P<ThreatFamilyName>[\w\&]*)")
+    r = re.compile(r"/(?P<ThreatPurpose>\w+\s?\w+)"
+                   r"(:|/)(?P<ResourceTypeAffected>\w*)"
+                   r"(/|.|-)(?P<ThreatFamilyName>[\w\&]*)")
     m = r.match(logdata['type'])
     gd = {'severitylabel': label, 'ThreatPurpose': m['ThreatPurpose'],
           'ResourceTypeAffected': m['ResourceTypeAffected'],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is similar to the Regex fix here: https://github.com/aws-samples/siem-on-amazon-opensearch-service/pull/182

The regex patterns are different for the GuardDuty implementation in SecurityHub vs GuardDuty.

Is that expected?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
