### PR TITLE
Support AWS Trusted Advisor logs #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ SIEM on OpenSearch Service can load and correlate the following log types.
 |Security, Identity, & Compliance|AWS Network Firewall|Flow logs<br>Alert logs|
 |Management & Governance|AWS CloudTrail|CloudTrail Log Event<br>CloudTrail Insight Event|
 |Management & Governance|AWS Config|Configuration History<br>Configuration Snapshot<br>Config Rules|
+|Management & Governance|AWS Trusted Advisor|Trusted Advisor Check Result|
 |Networking & Content Delivery|Amazon CloudFront|Standard access log<br>Real-time log|
 |Networking & Content Delivery|Amazon Route 53 Resolver|VPC DNS query log|
 |Networking & Content Delivery|Amazon Virtual Private Cloud (Amazon VPC)|VPC Flow Logs (Version5)|

--- a/README_ja.md
+++ b/README_ja.md
@@ -28,6 +28,7 @@ SIEM on OpenSearch Service は以下のログを取り込むことができま�
 |セキュリティ、ID、およびコンプライアンス|AWS Network Firewall|Flow logs<br>Alert logs|
 |管理とガバナンス|AWS CloudTrail|CloudTrail Log Event<br>CloudTrail Insight Event|
 |管理とガバナンス|AWS Config|Configuration 履歴<br>Configuration スナップショット<br>Config Rules|
+|管理とガバナンス|AWS Trusted Advisor|Trusted Advisor チェック結果|
 |ネットワーキングとコンテンツ配信|Amazon CloudFront|Standard access log<br>Real-time log|
 |ネットワーキングとコンテンツ配信|Amazon Route 53 Resolver|VPC DNS query log|
 |ネットワーキングとコンテンツ配信|Amazon Virtual Private Cloud (Amazon VPC)|VPC Flow Logs (Version5)|

--- a/docs/configure_aws_service.md
+++ b/docs/configure_aws_service.md
@@ -16,6 +16,7 @@ On this page, we’ll walk you through how to load logs from each AWS service in
 1. [Management & Governance](#3-Management--Governance)
     * [AWS CloudTrail](#AWS-CloudTrail)
     * [AWS Config](#AWS-Config)
+    * [AWS Trusted Advisor](#AWS-Trusted-Advisor)
 1. [Networking & Content Delivery](#4-Networking--Content-Delivery)
     * [Amazon CloudFront](#Amazon-CloudFront)
     * [Route 53 Resolver VPC DNS Query Logging](#Route-53-Resolver-VPC-DNS-Query-Logging)
@@ -283,6 +284,19 @@ The initial value of s3_key: `Config.*Rules` (specified in the Firehose output p
 |----------|----------------|---------------|
 | 1 |[![core resource](./images/cloudformation-launch-stack-button.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/template?stackName=log-exporter-core-resource&templateURL=https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-core.template) [link](https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-core.template) | CloudFormation for core resource. This template gets the S3 bucket name of the log forwarding destination and creates IAM roles. Commonly used in other AWS service settings. |
 | 2 |[![eventbridge](./images/cloudformation-launch-stack-button.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=log-exporter-eventbridge-events&templateURL=https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-eventbridge-events.template) [link](https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-eventbridge-events.template) | This template creates Firehose,set up EventBridge to deliver Events to the Firehose. A template common to Security Hub and Config Rules. |
+
+### AWS Trusted Advisor
+
+![ConfigRules to S3](images/trustedadvisor-check-result-to-s3.svg)
+
+The initial value of s3_key: `(TrustedAdvisor|trustedadvisor)` (specified in the Firehose output path)
+
+#### Configure by CloudFormation (AWS Trusted Advisor)
+
+| No | CloudFormation | Description |
+|----------|----------------|---------------|
+| 1 |[![core resource](./images/cloudformation-launch-stack-button.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/template?stackName=log-exporter-core-resource&templateURL=https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-core.template) [link](https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-core.template) | CloudFormation for core resource. This template gets the S3 bucket name of the log forwarding destination and creates IAM roles. Commonly used in other AWS service settings. |
+| 2 |[![trustedadvisor](./images/cloudformation-launch-stack-button.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=log-exporter-trustedadvisor&templateURL=https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-trustedadvisor.template) [link](https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-trustedadvisor.template) | This template creates Lambda,set up EventBridge to export Trusted Advisor check results to S3. |
 
 ## 4. Networking & Content Delivery
 

--- a/docs/configure_aws_service_ja.md
+++ b/docs/configure_aws_service_ja.md
@@ -16,6 +16,7 @@ SIEM on Amazon OpenSearch Service に AWS の各サービスのログを取り�
 1. [管理とガバナンス](#3-管理とガバナンス)
     * [AWS CloudTrail](#AWS-CloudTrail)
     * [AWS Config](#AWS-Config)
+    * [AWS Trusted Advisor](#AWS-Trusted-Advisor)
 1. [ネットワーキングとコンテンツ配信](#4-ネットワーキングとコンテンツ配信)
     * [Amazon CloudFront](#Amazon-CloudFront)
     * [Route 53 Resolver VPC DNS Query Log](#Route-53-Resolver-VPC-DNS-Query-Log)
@@ -302,6 +303,19 @@ s3_key の初期値: `Config.*Rules` (Firehose の出力パスに指定)
 |----------|----------------|---------------|
 | 1 |[![core resource](./images/cloudformation-launch-stack-button.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/template?stackName=log-exporter-core-resource&templateURL=https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-core.template) [link](https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-core.template) | 基本設定の CloudFormation。ログ転送先の S3 バケット名の取得や IAM ロールを作成します。他の AWS サービス設定で共通に使用します |
 | 2 |[![eventbridge](./images/cloudformation-launch-stack-button.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=log-exporter-eventbridge-events&templateURL=https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-eventbridge-events.template) [link](https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-eventbridge-events.template) | Firehose を作成。EventBridge を設定して Events を Firehose に配信します。Security Hub と Config Rules 共通のテンプレート。|
+
+### AWS Trusted Advisor
+
+![Trusted Advisor check result to S3](images/trustedadvisor-check-result-to-s3.svg)
+
+s3_key の初期値: `(TrustedAdvisor|trustedadvisor)` Lambda functionにより固定値で出力されるので設定不要。
+
+#### CloudFormation による設定 (Trusted Advisor)
+
+| No | CloudFormation | 説明 |
+|----------|----------------|---------------|
+| 1 |[![core resource](./images/cloudformation-launch-stack-button.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/template?stackName=log-exporter-core-resource&templateURL=https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-core.template) [link](https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-core.template) | 基本設定の CloudFormation。ログ転送先の S3 バケット名の取得や IAM ロールを作成します。他の AWS サービス設定で共通に使用します |
+| 2 |[![trustedadvisor](./images/cloudformation-launch-stack-button.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=log-exporter-trustedadvisor&templateURL=https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-trustedadvisor.template) [link](https://aes-siem.s3.ap-northeast-1.amazonaws.com/beta/log-exporter/siem-log-exporter-trustedadvisor.template) | Lambda を作成。EventBridge を設定して Lambda を定期実行し、Trusted Advisor チェック結果 を S3 に書き出します。|
 
 ## 4. ネットワーキングとコンテンツ配信
 

--- a/source/cdk-deployment-samples/app.py
+++ b/source/cdk-deployment-samples/app.py
@@ -17,6 +17,7 @@ from deployment_samples.deployment_samples_stack import (
     DeploymentSamplesStack,
     EventBridgeEventsExporterStack,
     FirehoseExporterStack,
+    TrustedAdvisorLogExporterStack,
     WorkSpacesLogExporterStack,
 )
 
@@ -40,6 +41,10 @@ workspaces_logging = WorkSpacesLogExporterStack(
     app, "siem-log-exporter-workspaces",
     description=(f'SIEM on Amazon OpenSearch Service v{__version__}: '
                  'log exporter - Workspaces'))
+trustedadvisor_logging = TrustedAdvisorLogExporterStack(
+    app, "siem-log-exporter-trustedadvisor",
+    description=(f'SIEM on Amazon OpenSearch Service v{__version__}: '
+                 'log exporter - TrustedAdvisor'))
 ad_logging = ADLogExporterStack(
     app, "siem-log-exporter-ad",
     description=(f'SIEM on Amazon OpenSearch Service v{__version__}: '

--- a/source/lambda/deploy_es/data.ini
+++ b/source/lambda/deploy_es/data.ini
@@ -719,6 +719,42 @@ component_template_log-aws-workspaces = {
   }
  }
 
+component_template_log-aws-trustedadvisor = {
+  "template": {
+    "mappings" : {
+      "properties": {
+        "check.id": {"type": "keyword"},
+        "check.name": {"type": "keyword"},
+        "check.description": {"type": "text"},
+        "check.category": {"type": "keyword"},
+        "check.metadata": {"type": "keyword"},
+        "check_ja.id": {"type": "keyword"},
+        "check_ja.name": {"type": "keyword"},
+        "check_ja.description": {"type": "text"},
+        "check_ja.category": {"type": "keyword"},
+        "check_ja.metadata": {"type": "keyword"},
+        "refreshable": {"type": "boolean"},
+        "result.checkId": {"type": "keyword"},
+        "result.flaggedResource.isSuppressed": {"type": "boolean"},
+        "result.flaggedResource.metadata": {"type": "keyword"},
+        "result.flaggedResource.number": {"type": "integer"},
+        "result.flaggedResource.region": {"type": "keyword"},
+        "result.flaggedResource.resourceId": {"type": "keyword"},
+        "result.flaggedResource.status": {"type": "keyword"},
+        "result.flaggedResources": {"type": "text"},
+        "result.resourcesSummary.resourcesFlagged": {"type": "integer"},
+        "result.resourcesSummary.resourcesIgnored": {"type": "integer"},
+        "result.resourcesSummary.resourcesProcessed": {"type": "integer"},
+        "result.resourcesSummary.resourcesSuppressed": {"type": "integer"},
+        "result.status": {"type": "keyword"},
+        "result.timestamp": {"type": "date"},
+        "result.categorySpecificSummary.costOptimizing.estimatedMonthlySavings": {"type": "integer"},
+        "result.categorySpecificSummary.costOptimizing.estimatedPercentMonthlySavings": {"type": "integer"}
+      }
+    }
+  }
+ }
+
 component_template_log-linux = {
   "template": {
     "mappings" : {
@@ -866,6 +902,17 @@ log-aws-workspaces_aws = {
     "component_template_log",
     "component_template_log-aws",
     "component_template_log-aws-workspaces"
+  ],
+  "version": 1
+ }
+
+log-aws-trustedadvisor_aws = {
+  "index_patterns": ["log-aws-trustedadvisor-*"],
+  "priority": 2,
+  "composed_of": [
+    "component_template_log",
+    "component_template_log-aws",
+    "component_template_log-aws-trustedadvisor"
   ],
   "version": 1
  }

--- a/source/lambda/es_loader/aws.ini
+++ b/source/lambda/es_loader/aws.ini
@@ -1247,6 +1247,22 @@ event.category = [host]
 event.type = [info]
 
 
+[trustedadvisor]
+s3_key = (TrustedAdvisor|trustedadvisor)
+index_name = log-aws-trustedadvisor
+file_format = json
+timestamp_key = time
+timestamp_format = iso8601
+
+static_ecs = event.kind event.category event.type event.module
+event.kind = event
+event.category = configuration
+event.type = info
+event.module = trustedadvisor
+
+script_ecs = event.category event.kind
+
+
 [directory-service]
 s3_key = /DirectoryService/MicrosoftAD/
 index_name = log-aws-directory-service


### PR DESCRIPTION
*Issue #, if available: #8

*Description of changes: 
To support the check result of AWS Trusted Advisor, I added a lambda function that runs the Support API on a regular basis and writes out the AWS Trusted Advisor check results as a log, and a script to read the log into Amazon OpenSearch Service.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
