### PR TITLE
feature: add support for SNS

### DIFF
--- a/source/lambda/es_loader/index.py
+++ b/source/lambda/es_loader/index.py
@@ -303,6 +303,15 @@ utils.show_local_dir()
 @observability_decorator_switcher
 def lambda_handler(event, context):
     for record in event['Records']:
+        if 'EventSource' in record and record['EventSource'] == 'aws:sns':
+            recs = json.loads(record['Sns']['Message'])
+            process_records(recs['Records'])
+        else:
+            process_records([record])
+    
+
+def process_records(records):
+    for record in records:
         collected_metrics = {'start_time': time.perf_counter()}
         if 'body' in record:
             # from sqs-splitted-logs


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change improves the extensibility of the solution by allowing the es_loader to consume events from SNS. In the current architecture, S3 notifications are configured to invoke Lambda. This excludes customers from adding any other S3 event notifications for the same S3 event types and suffix. Instead, customers can create S3 notifications that get published to SNS allowing for a fan-out architecture. The es_loader needs an update to 'unwrap' the SNSEvent message to get to the expected message. This PR implements a supporting change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
