### PR TITLE
Remove leading slash that causes bad request to Opensearch

### DIFF
--- a/source/lambda/deploy_es/index.py
+++ b/source/lambda/deploy_es/index.py
@@ -245,7 +245,7 @@ def output_message(key, res):
 
 def get_dist_version(es_endpoint):
     awsauth = auth_aes(es_endpoint)
-    res = query_aes(es_endpoint, awsauth, method='get', path='/')
+    res = query_aes(es_endpoint, awsauth, method='get', path='')
     logger.info(res.text)
     version = json.loads(res.text)['version']
     domain_version = version['number']


### PR DESCRIPTION
*Description of changes:*
Remove leading trail here, since it causes a double slash when querying to OpenSearch, causing a 400 Bad Request, failing provisioning