### PR TITLE
Delete old v1 index templates

### DIFF
--- a/source/lambda/deploy_es/data.ini
+++ b/source/lambda/deploy_es/data.ini
@@ -2293,8 +2293,11 @@ log-aws-vpcflowlogs_aws = None
 log-aws-waf_aws = None
 log-aws-workspaces_aws = None
 log-linux_aws = None
+log-linux-secure_aws = None
 log-win_aws = None
 
+log-aws-cloudfront_rollover = None
+log-aws-cloudtrail_rollover = None
 log-aws-directory-service_rollover = None
 log-aws-elb_rollover = None
 log-aws-fsx-win_rollover = None


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Deleted following v1 index templates. Updated to v2.8.0, but some templates remained.

- log-linux-secure_aws
- log-aws-cloudfront_rollover
- log-aws-cloudtrail_rollover

## log-linux-secure-aws
```json
{
  "log-linux-secure_aws" : {
    "order" : 0,
    "index_patterns" : [
      "log-linux-secure-*"
    ],
    "settings" : { },
    "mappings" : {
      "properties" : {
        "syslog_timestamp" : {
          "type" : "keyword"
        },
        "pid" : {
          "type" : "integer"
        },
        "message" : {
          "type" : "text"
        }
      }
    },
    "aliases" : { }
  }
}
```

## log-aws-cloudfront_rollover
```json
{
  "log-aws-cloudfront_rollover" : {
    "order" : 0,
    "index_patterns" : [
      "log-aws-cloudfront-0*"
    ],
    "settings" : {
      "index" : {
        "opendistro" : {
          "index_state_management" : {
            "policy_id" : "rollover100gb",
            "rollover_alias" : "log-aws-cloudfront"
          }
        }
      }
    },
    "mappings" : { },
    "aliases" : { }
  }
}
```

## log-aws-cloudtrail_rollover
```json
{
  "log-aws-cloudtrail_rollover" : {
    "order" : 0,
    "index_patterns" : [
      "log-aws-cloudtrail-0*"
    ],
    "settings" : {
      "index" : {
        "opendistro" : {
          "index_state_management" : {
            "policy_id" : "rollover100gb",
            "rollover_alias" : "log-aws-cloudtrail"
          }
        }
      }
    },
    "mappings" : { },
    "aliases" : { }
  }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
