### PR TITLE
Fix field larger than field limit (131072) error

### DIFF
--- a/source/lambda/es_loader/siem/fileformat_csv.py
+++ b/source/lambda/es_loader/siem/fileformat_csv.py
@@ -16,6 +16,7 @@ from siem import FileFormatBase
 
 logger = Logger(child=True)
 
+csv.field_size_limit(1000000)
 
 class FileFormatCsv(FileFormatBase):
     def __init__(self, rawdata=None, logconfig=None, logtype=None):


### PR DESCRIPTION
*Issue #, if available:*
#338 

*Description of changes:*

Changed CSV field limit value  from default (131,072) to big value (1,000,000).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
