### PR TITLE
allow multiple events in a cwl event

### DIFF
--- a/source/lambda/es_loader/siem/__init__.py
+++ b/source/lambda/es_loader/siem/__init__.py
@@ -230,7 +230,12 @@ class LogS3:
             for lograw, logmeta in self.extract_cwl_log(start, end, logmeta):
                 logdict = self.rawfile_instacne.convert_lograw_to_dict(lograw)
                 if isinstance(logdict, dict):
-                    yield (lograw, logdict, logmeta)
+                    if "json_delimiter" in self.logconfig or "csv_delimiter" in self.logconfig
+                        # multiple events in 1 json
+                        for record in utils.value_from_nesteddict_by_dottedkey(logdict,self.logconfig["json_delimiter"]):
+                            yield (json.dumps(record, ensure_ascii=False), record, logmeta)
+                    else:
+                        yield (lograw, logdict, logmeta)
                 elif logdict == 'regex_error':
                     self.error_logs_count += 1
         elif self.via_firelens:


### PR DESCRIPTION
This change allow the use of 'delimiters' in addition to cloudwatch logs events split.
In my case, it is useful to get SecurityHub Findings via CloudWatch Logs.
https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cwe-all-findings.html
My current customer did that setup following an LAZ guideline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
