### PR TITLE
fix: Adjust SQS visibility timeout to appropriate value

### DIFF
--- a/source/cdk/mysiem/aes_siem_stack.py
+++ b/source/cdk/mysiem/aes_siem_stack.py
@@ -1220,7 +1220,7 @@ class MyAesSiemStack(cdk.Stack):
             data_key_reuse=cdk.Duration.hours(24),
             dead_letter_queue=aws_sqs.DeadLetterQueue(
                 max_receive_count=20, queue=sqs_aes_siem_dlq),
-            visibility_timeout=cdk.Duration.seconds(ES_LOADER_TIMEOUT),
+            visibility_timeout=cdk.Duration.seconds(ES_LOADER_TIMEOUT * 6),
             retention_period=cdk.Duration.days(14))
 
         ######################################################################


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When connecting SQS with Lambda, it is recommended to set the visibility timeout to six times the Lambda function's timeout value. The visibility timeout should be at least longer than the Lambda function's timeout multiplied by the number of retries.  
https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html

(JP)
SQSとLambdaを接続する場合にはLambdaのタイムアウトの6倍の値を可視性タイムアウトにすることが推奨されています。
少なくともLambdaのタイムアウト*試行回数より長い可視性タイムアウトを取る必要があります。

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
