### PR TITLE
Fix: Add Lambda ListTags permission

### DIFF
--- a/deployment/siem-on-amazon-opensearch-service-china.template
+++ b/deployment/siem-on-amazon-opensearch-service-china.template
@@ -1409,6 +1409,7 @@ Resources:
               - Action:
                   - lambda:UpdateFunctionConfiguration
                   - lambda:GetFunction
+                  - lambda:ListTags
                 Effect: Allow
                 Resource: !GetAtt 'LambdaEsLoader4B1E2DD9.Arn'
               - Action: lambda:PublishLayerVersion

--- a/deployment/siem-on-amazon-opensearch-service-no-alb-account.template
+++ b/deployment/siem-on-amazon-opensearch-service-no-alb-account.template
@@ -1406,6 +1406,7 @@ Resources:
               - Action:
                   - lambda:UpdateFunctionConfiguration
                   - lambda:GetFunction
+                  - lambda:ListTags
                 Effect: Allow
                 Resource: !GetAtt 'LambdaEsLoader4B1E2DD9.Arn'
               - Action: lambda:PublishLayerVersion

--- a/deployment/siem-on-amazon-opensearch-service-usgov.template
+++ b/deployment/siem-on-amazon-opensearch-service-usgov.template
@@ -1409,6 +1409,7 @@ Resources:
               - Action:
                   - lambda:UpdateFunctionConfiguration
                   - lambda:GetFunction
+                  - lambda:ListTags
                 Effect: Allow
                 Resource: !GetAtt 'LambdaEsLoader4B1E2DD9.Arn'
               - Action: lambda:PublishLayerVersion

--- a/deployment/siem-on-amazon-opensearch-service.template
+++ b/deployment/siem-on-amazon-opensearch-service.template
@@ -1409,6 +1409,7 @@ Resources:
               - Action:
                   - lambda:UpdateFunctionConfiguration
                   - lambda:GetFunction
+                  - lambda:ListTags
                 Effect: Allow
                 Resource: !GetAtt 'LambdaEsLoader4B1E2DD9.Arn'
               - Action: lambda:PublishLayerVersion

--- a/source/cdk/mysiem/helper_lambda_functions.py
+++ b/source/cdk/mysiem/helper_lambda_functions.py
@@ -63,7 +63,8 @@ class HelperLambdaFunctions(object):
                     statements=[
                         aws_iam.PolicyStatement(
                             actions=['lambda:UpdateFunctionConfiguration',
-                                     'lambda:GetFunction'],
+                                     'lambda:GetFunction',
+                                     'lambda:ListTags'],
                             resources=[self.lambda_es_loader.function_arn]),
                         aws_iam.PolicyStatement(
                             actions=['lambda:PublishLayerVersion'],


### PR DESCRIPTION
*Issue #, if available:* [#461](https://github.com/aws-samples/siem-on-amazon-opensearch-service/issues/461)

*Description of changes:*

When using `lambda:GetFunction` on tagged Lambda functions, the `lambda:ListTags` permission is also [required](https://docs.aws.amazon.com/lambda/latest/dg/configuration-tags.html#permissions-required-for-working-with-tags-cli).



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
