### PR TITLE
Update lambda runtime to nodejs 20

### DIFF
--- a/deployment/siem-on-amazon-opensearch-service-china.template
+++ b/deployment/siem-on-amazon-opensearch-service-china.template
@@ -816,7 +816,7 @@ Resources:
       FunctionName: aes-siem-aws-api-caller
       Handler: index.handler
       Role: !GetAtt 'AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs20.x
       Timeout: 30
     DependsOn:
       - AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2

--- a/deployment/siem-on-amazon-opensearch-service-no-alb-account.template
+++ b/deployment/siem-on-amazon-opensearch-service-no-alb-account.template
@@ -813,7 +813,7 @@ Resources:
       FunctionName: aes-siem-aws-api-caller
       Handler: index.handler
       Role: !GetAtt 'AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs20.x
       Timeout: 30
     DependsOn:
       - AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2

--- a/deployment/siem-on-amazon-opensearch-service-usgov.template
+++ b/deployment/siem-on-amazon-opensearch-service-usgov.template
@@ -816,7 +816,7 @@ Resources:
       FunctionName: aes-siem-aws-api-caller
       Handler: index.handler
       Role: !GetAtt 'AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs20.x
       Timeout: 30
     DependsOn:
       - AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2

--- a/deployment/siem-on-amazon-opensearch-service.template
+++ b/deployment/siem-on-amazon-opensearch-service.template
@@ -816,7 +816,7 @@ Resources:
       FunctionName: aes-siem-aws-api-caller
       Handler: index.handler
       Role: !GetAtt 'AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2.Arn'
-      Runtime: nodejs18.x
+      Runtime: nodejs20.x
       Timeout: 30
     DependsOn:
       - AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2


### PR DESCRIPTION
*Issue #, if available:*
* Close: https://github.com/aws-samples/siem-on-amazon-opensearch-service/issues/468

*Description of changes:*
* Upgrade the runtime version to Node.js 20, as the Node.js 18 runtime will reach end of support on September 1, 2025.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
